### PR TITLE
nor.request(url, =conf) -> promise<request, error>

### DIFF
--- a/js/nor.js
+++ b/js/nor.js
@@ -14,21 +14,22 @@ var nor = {
       "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
     };
     var parameters;
-    for (var prop in config) {
-      if (config.hasOwnProperty(prop)) {
-        var value = config[prop];
-
-        if (prop === "method") {
-          method = value;
-        } else if (prop === "data") {
-          parameters = value;
-        } else if (prop === "headers" && value.constructor === Object) {
-          for (var header in value) headers[header] = value;
-        } else if (prop === "cors") {
-          headers["Access-Control-Allow-Origin"] =  typeof value === "string"
-            ? value : value === true ? "*" : undefined;
-        } else if (prop === "type") {
-          headers["Content-Type"] = value;
+    if (config != null && config.constructor === Object) {
+      for (var prop in config) {
+        if (config.hasOwnProperty(prop)) {
+          var value = config[prop];
+          if (prop === "method") {
+            method = value;
+          } else if (prop === "data") {
+            parameters = value;
+          } else if (prop === "headers" && value.constructor === Object) {
+            for (var header in value) headers[header] = value;
+          } else if (prop === "cors") {
+            headers["Access-Control-Allow-Origin"] = typeof value === "string"
+              ? value : value === true ? "*" : undefined;
+          } else if (prop === "type") {
+            headers["Content-Type"] = value;
+          }
         }
       }
     }
@@ -36,7 +37,6 @@ var nor = {
     return new Promise(function(resolve, reject) {
       var request = new XMLHttpRequest();
       request.onload = function() {
-        var status = request.status;
         // resolve the request when successful
         if (request.status === 200 || request.statusText === "OK") {
           resolve(request);


### PR DESCRIPTION
Promises are really easy to polyfill for older browsers and it's a much more standard way of handling success/error situations like with http requests.

The native javascript ``fetch`` uses promises this way.
```js
 fetch('https://raw.githubusercontent.com/Norair1997/norjs/master/js/nor.js')
 .then(res => res.text())
 .then(text => {
    nor.createObject('script', {parent: document.head}, text)
 })
```

This is what requests would look like with these changes.
```js
nor.request('https://raw.githubusercontent.com/Norair1997/norjs/master/js/nor.js', {
   type: 'application/javascript',
   headers: {
     'X-Custom-Header': '001, some_data_point=43'
   }
}).then(req => {
   nor.createObject('script', {parent: document.head}, req.response)
}).catch(err => {
  console.error(err)
  // or do something with: err.request
})
```
There's still things you could add like ``req.ontimeout`` error handling or a more semantic API like axios.

oh and this is now possible

```js
 (async () => {
   const {response} = await nor.request('http://someapp.com/resource.txt')
   // do something
 })()
```

Also consider adding something like this
```js
nor.request.get('url', conf).then(responseHandler, errorHandler)
nor.request.post('url', conf).then(responseHandler, errorHandler)
// ...
// or maybe
try {
 const {token} = JSON.parse(
	localStorage.getItem('user') ||
    await nor.http.post('/validate- user', {
	 type: 'application/json',
     body: {
       username: authFrom.username,
       email: authForm.email
     }
    }).request.response
 )

nor.http.get('/user-profile?token=' + token).then(res => {
  const profileData = JSON.parse(res.response)
  app.buildUserPage(profileData)
})
} catch (e) {}

```